### PR TITLE
request|response now support std::span<char> parses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
                         cmake \
                         git \
                         ninja-build \
-                        g++-9 \
-                        clang-9
+                        g++-10 \
+                        clang-10
             -   name: build-release-g++
                 run: |
                     mkdir build-release-g++
@@ -33,8 +33,8 @@ jobs:
                     cmake \
                         -GNinja \
                         -DCMAKE_BUILD_TYPE=Release \
-                        -DCMAKE_C_COMPILER=gcc-9 \
-                        -DCMAKE_CXX_COMPILER=g++-9 \
+                        -DCMAKE_C_COMPILER=gcc-10 \
+                        -DCMAKE_CXX_COMPILER=g++-10 \
                         ..
                     ninja
             -   name: build-release-clang
@@ -44,8 +44,8 @@ jobs:
                     cmake \
                         -GNinja \
                         -DCMAKE_BUILD_TYPE=Release \
-                        -DCMAKE_C_COMPILER=clang-9 \
-                        -DCMAKE_CXX_COMPILER=clang++-9 \
+                        -DCMAKE_C_COMPILER=clang-10 \
+                        -DCMAKE_CXX_COMPILER=clang++-10 \
                         ..
                     ninja
             -   name: test-release-g++

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ set(LIBTURBOHTTP_SOURCE_FILES
 
 add_library(${PROJECT_NAME} STATIC ${LIBTURBOHTTP_SOURCE_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
-target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
 target_include_directories(${PROJECT_NAME} PUBLIC src)
 target_compile_definitions(${PROJECT_NAME} PRIVATE ${TURBOHTTP_HEADER_COUNT})
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-libturbohttp - C++17 HTTP/1.1 Request and Response stateful parser.
+libturbohttp - C++20 HTTP/1.1 Request and Response stateful parser.
 ===================================================================
 
 [![CI](https://github.com/jbaldwin/libturbohttp/workflows/build/badge.svg)](https://github.com/jbaldwin/libturbohttp/workflows/build/badge.svg)
@@ -6,18 +6,18 @@ libturbohttp - C++17 HTTP/1.1 Request and Response stateful parser.
 [![language][badge.language]][language]
 [![license][badge.license]][license]
 
-[badge.language]: https://img.shields.io/badge/language-C%2B%2B17-yellow.svg
+[badge.language]: https://img.shields.io/badge/language-C%2B%2B20-yellow.svg
 [badge.license]: https://img.shields.io/badge/license-Apache--2.0-blue
 
 [language]: https://en.wikipedia.org/wiki/C%2B%2B17
 [license]: https://en.wikipedia.org/wiki/Apache_License
 
-**libturbohttp** is a C++17 HTTP/1.1 Request and Response stateful parser with zero memory allocations.  The intended purpose of this library is to provide a high quality and extremely fast stateful HTTP/1.1 parser with modern C++ coding standards.
+**libturbohttp** is a C++20 HTTP/1.1 Request and Response stateful parser with zero memory allocations.  The intended purpose of this library is to provide a high quality and extremely fast stateful HTTP/1.1 parser with modern C++ coding standards.
 
 **libturbohttp** is licensed under the Apache 2.0 license.
 
 # Overview #
-* Modern C++17 API
+* Modern C++20 API
 * Stateful parser, continue parsing where the previous call left off at when partial requests and responses are provided.
 * Zero allocation parsing, The request and response objects can be created on the stack and do not allocate any memory when parsing.
 * Custom maximum number of headers for request and response objects, default is 16.
@@ -128,7 +128,7 @@ while(!done)
 ```
 
 ## Requirements
-* C++17
+* C++20
 * gcc or clang
 * Tested on ubuntu and fedora.
 

--- a/src/turbohttp/parser.hpp
+++ b/src/turbohttp/parser.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <optional>
 #include <array>
+#include <span>
 
 // The cmake build system will define this and allows overriding.
 #ifndef TURBOHTTP_HEADER_COUNT
@@ -88,12 +89,14 @@ public:
      */
     auto parse(std::string& data) -> request_parse_result;
 
+    auto parse(std::span<char>& data) -> request_parse_result;
+
 private:
-    auto parse_method(std::string& data) -> request_parse_result;
-    auto parse_uri(std::string& data) -> request_parse_result;
-    auto parse_version(std::string& data) -> request_parse_result;
-    auto parse_headers(std::string& data) -> request_parse_result;
-    auto parse_body(std::string& data) -> request_parse_result;
+    auto parse_method(std::span<char>& data) -> request_parse_result;
+    auto parse_uri(std::span<char>& data) -> request_parse_result;
+    auto parse_version(std::span<char>& data) -> request_parse_result;
+    auto parse_headers(std::span<char>& data) -> request_parse_result;
+    auto parse_body(std::span<char>& data) -> request_parse_result;
 public:
 
     /**
@@ -223,12 +226,13 @@ public:
     auto operator=(response&&) -> response& = default;
 
     auto parse(std::string& data) -> response_parse_result;
+    auto parse(std::span<char>& data) -> response_parse_result;
 private:
-    auto parse_version(std::string& data) -> response_parse_result;
-    auto parse_status_code(std::string& data) -> response_parse_result;
-    auto parse_reason_phrase(std::string& data) -> response_parse_result;
-    auto parse_headers(std::string& data) -> response_parse_result;
-    auto parse_body(std::string& data) -> response_parse_result;
+    auto parse_version(std::span<char>& data) -> response_parse_result;
+    auto parse_status_code(std::span<char>& data) -> response_parse_result;
+    auto parse_reason_phrase(std::span<char>& data) -> response_parse_result;
+    auto parse_headers(std::span<char>& data) -> response_parse_result;
+    auto parse_body(std::span<char>& data) -> response_parse_result;
 public:
 
     /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,6 @@ cmake_minimum_required(VERSION 3.16)
 project(libturbohttp_test)
 
 set(LIBTURBOHTTP_TEST_SOURCE_FILES
-    main.cpp
     test_parse_request.cpp
     test_parse_response.cpp
 )


### PR DESCRIPTION
This allows for buffers to be pre-allocated to larger
sizes than the actual input data and then only the
bytes received are parsed.  This was a direct problem
when testing with scopuli that the input buffer was
initialized to 4k but the incoming data was only several
hundred bytes, causing the parser to say the request was
incomplete since there were 3,800~ missing bytes